### PR TITLE
GloopAnalytics.i18n.alias.php: Minor changes

### DIFF
--- a/GloopAnalytics.i18n.alias.php
+++ b/GloopAnalytics.i18n.alias.php
@@ -2,12 +2,12 @@
 
 $specialPageAliases = [];
 
-$specialPageAliases[ 'de' ] = [
-	'Analytics' => [ 'Analysen' ],
-];
-
 $specialPageAliases[ 'en' ] = [
 	'Analytics' => [ 'Analytics' ],
+];
+
+$specialPageAliases[ 'de' ] = [
+	'Analytics' => [ 'Analysen' ],
 ];
 
 $specialPageAliases[ 'ja' ] = [
@@ -20,6 +20,10 @@ $specialPageAliases[ 'pt' ] = [
 
 $specialPageAliases[ 'uk' ] = [
 	'Analytics' => [ 'Аналітика' ],
+];
+
+$specialPageAliases[ 'zh' ] = [
+	'Analytics' => [ 'Analytics' ],
 ];
 
 $specialPageAliases[ 'zh-hans' ] = [


### PR DESCRIPTION
What:
* Move "en" to the first one, in conventions of other extensions
* Use English name as Chinese (zh) primary, in consistency of [gerrit:1118140](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1118140)